### PR TITLE
chore: Configure custom registry certificate in Docker Compose

### DIFF
--- a/compose/dind/certs.d/README.md
+++ b/compose/dind/certs.d/README.md
@@ -1,0 +1,18 @@
+# `/etc/docker/certs.d`
+
+This directory allows you to configure custom [registry certificates][registry-certificates].
+It's mounted at `/etc/docker/certs.d` in the `dind` container (see `docker-compose.yaml`):
+
+```
+/etc/docker/certs.d/            <-- Certificates directory
+    |-- localhost:5000          <-- Hostname:port
+    |  |-- client.cert          <-- Client certificate
+    |  |-- client.key           <-- Client key
+    |  `-- ca.crt               <-- Certificate authority that signed the registry certificate
+    `-- core.harbor.domain      <-- Harbor registry hostname:port
+        `-- ca.crt              <-- Certificate authority that signed the Harbor registry certificate
+```
+
+TODO Describe how to configure insecure registries (nice to have for development).
+
+[registry-certificates]: https://docs.docker.com/engine/security/certificates/

--- a/compose/dind/certs.d/core.harbor.domain/ca.crt
+++ b/compose/dind/certs.d/core.harbor.domain/ca.crt
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+Certificate authority that signed the Harbor registry certificate goes here.
+-----END CERTIFICATE-----

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - scanner
     volumes:
       - dind-data:/var/lib/docker
+      - ./dind/certs.d:/etc/docker/certs.d
   redis:
     image: redis:5.0.5
     ports:


### PR DESCRIPTION
This one is to allow configuring custom certificate authority that signed the Harbor registry certificate. Otherwise wrapper script fails with x509: certificate signed by unknown authority error