### PR TITLE
chore: Update k8s deployment descriptors

### DIFF
--- a/cmd/scanner-microscanner/main.go
+++ b/cmd/scanner-microscanner/main.go
@@ -18,6 +18,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
 	log.SetReportCaller(false)
+	log.SetFormatter(&log.JSONFormatter{})
 }
 
 func main() {
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("Error: %v", err)
 	}
 
-	log.Infof("Starting harbor-scanner-microscanner with config %v", cfg)
+	log.Info("Starting harbor-scanner-microscanner")
 
 	wrapper := microscanner.NewWrapper(cfg.MicroScanner)
 	transformer := model.NewTransformer()

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       SCANNER_API_ADDR: ":8080"
       SCANNER_DOCKER_HOST: "tcp://dind:2375"
       SCANNER_MICROSCANNER_TOKEN: ${SCANNER_MICROSCANNER_TOKEN}
-      SCANNER_MICROSCANNER_OPTIONS: "--continue-on-failure"
+      SCANNER_MICROSCANNER_OPTIONS: "--continue-on-failure --full-output"
       SCANNER_STORE_DRIVER: "redis"
       SCANNER_STORE_REDIS_URL: "redis://redis:6379"
       SCANNER_JOB_QUEUE_REDIS_URL: "redis://redis:6379"

--- a/kube/harbor-scanner-microscanner.yaml
+++ b/kube/harbor-scanner-microscanner.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: harbor-scanner-microscanner
+  labels:
+    app.kubernetes.io/name: harbor-scanner-microscanner
+    app.kubernetes.io/managed-by: kubectl
 spec:
   replicas: 1
   selector:
@@ -18,28 +21,25 @@ spec:
           image: aquasec/harbor-scanner-microscanner:poc
           imagePullPolicy: IfNotPresent
           env:
-            - name: "SCANNER_ADDR"
+            - name: "SCANNER_API_ADDR"
               value: ":8080"
             - name: "SCANNER_DOCKER_HOST"
               value: "tcp://localhost:2375"
-            - name: "SCANNER_STORE_DRIVER"
-              value: "fs"
-            - name: "SCANNER_STORE_FS_DATA_DIR"
-              value: "/data/scanner"
-            - name: "SCANNER_REGISTRY_URL"
-              value: "core.harbor.domain"
             - name: "SCANNER_MICROSCANNER_OPTIONS"
-              value: "-c"
+              value: "--continue-on-failure --full-output"
             - name: "SCANNER_MICROSCANNER_TOKEN"
               valueFrom:
                 secretKeyRef:
                   name: harbor-scanner-microscanner
                   key: microscanner-token
+            - name: "SCANNER_STORE_DRIVER"
+              value: "redis"
+            - name: "SCANNER_STORE_REDIS_URL"
+              value: "redis://harbor-harbor-redis:6379"
+            - name: "SCANNER_JOB_QUEUE_REDIS_URL"
+              value: "redis://harbor-harbor-redis:6379"
           ports:
             - containerPort: 8080
-          volumeMounts:
-            - mountPath: /data/scanner
-              name: microscanner-data
         - name: dind
           image: docker:18.05-dind
           imagePullPolicy: IfNotPresent
@@ -52,22 +52,26 @@ spec:
             - name: dind-storage
               mountPath: /var/lib/docker
             - name: dind-config
+              # Change core.harbor.domain to the Harbor registry hostname:port
               mountPath: /etc/docker/certs.d/core.harbor.domain
               readOnly: true
       volumes:
-        - name: microscanner-data
-          hostPath:
-            path: /data/microscanner
         - name: dind-storage
           emptyDir: {}
         - name: dind-config
-          secret:
-            secretName: harbor-scanner-microscanner-dind
+          configMap:
+            name: harbor-scanner-microscanner
+            items:
+              - key: harbor-registry-cert
+                path: ca.crt
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: harbor-scanner-microscanner
+  labels:
+    app.kubernetes.io/name: harbor-scanner-microscanner
+    app.kubernetes.io/managed-by: kubectl
 spec:
   selector:
     app: harbor-scanner-microscanner

--- a/pkg/job/work/queue.go
+++ b/pkg/job/work/queue.go
@@ -65,7 +65,9 @@ func (wq *workQueue) Stop() {
 }
 
 func (wq *workQueue) EnqueueScanJob(sr harbor.ScanRequest) (*job.ScanJob, error) {
-	log.Debugf("Enqueueing scan job for scan request ID %v", sr.ID)
+	log.WithFields(log.Fields{
+		"scan_request_id": sr.ID,
+	}).Debug("Enqueueing scan job")
 
 	b, err := json.Marshal(sr)
 	if err != nil {
@@ -78,7 +80,10 @@ func (wq *workQueue) EnqueueScanJob(sr harbor.ScanRequest) (*job.ScanJob, error)
 	if err != nil {
 		return nil, fmt.Errorf("enqueuing scan image job: %v", err)
 	}
-	log.Debugf("Successfully enqueued scan job with ID %v for scan request ID %v", j.ID, sr.ID)
+	log.WithFields(log.Fields{
+		"scan_job":        j.ID,
+		"scan_request_id": sr.ID,
+	}).Debug("Successfully enqueued scan job")
 
 	scanID, err := uuid.Parse(sr.ID)
 	if err != nil {
@@ -103,7 +108,10 @@ func (wq *workQueue) GetScanJob(scanID uuid.UUID) (*job.ScanJob, error) {
 }
 
 func (wq *workQueue) ExecuteScanJob(job *work.Job) error {
-	log.Debugf("Scan job started: %v", job.ID)
+	log.WithFields(log.Fields{
+		"scan_job": job.ID,
+	}).Debug("Scan job started")
+
 	scanner, ok := job.Args[scannerArg].(microscanner.Scanner)
 	if !ok {
 		return fmt.Errorf("getting scanner from job args")
@@ -124,6 +132,9 @@ func (wq *workQueue) ExecuteScanJob(job *work.Job) error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("Scan job finished: %s", job.ID)
+
+	log.WithFields(log.Fields{
+		"scan_job": job.ID,
+	}).Debug("Scan job finished")
 	return err
 }

--- a/pkg/model/transformer.go
+++ b/pkg/model/transformer.go
@@ -8,7 +8,7 @@ import (
 
 // Transformer wraps the Transform method.
 //
-// Transform transforms Microscanner's scan results model to Harbor's model.
+// Transform transforms MicroScanner's scan report to Harbor's os package vulnerability report.
 type Transformer interface {
 	Transform(sr *microscanner.ScanReport) (*harbor.VulnerabilityReport, error)
 }
@@ -54,7 +54,7 @@ func (t *transformer) toHarborSeverity(severity string) harbor.Severity {
 	case "low":
 		return harbor.SevLow
 	default:
-		log.Warnf("Unknown microscanner severity `%s`", severity)
+		log.WithField("severity", severity).Warn("Unknown microscanner severity")
 		return harbor.SevUnknown
 	}
 }

--- a/pkg/store/redis/store.go
+++ b/pkg/store/redis/store.go
@@ -74,7 +74,12 @@ func (rs *redisStore) GetScanJob(scanID uuid.UUID) (*job.ScanJob, error) {
 }
 
 func (rs *redisStore) UpdateScanJobStatus(scanID uuid.UUID, currentStatus, newStatus job.ScanJobStatus) error {
-	log.Debugf("Updating status from %v to %v for scan job %v", currentStatus, newStatus, scanID)
+	log.WithFields(log.Fields{
+		"scan_job": scanID.String(),
+		"current_status": currentStatus.String(),
+		"new_status": newStatus.String(),
+	}).Debug("Updating job status")
+
 	scanJob, err := rs.GetScanJob(scanID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Updating deployment yamls so we can run the scanner adapter on k8s cluster and test it with Harbor deployed to the same cluster.