### PR TITLE
chore: Generate ScanRequest identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ See [Pluggable Image Vulnerability Scanning Proposal][image-vulnerability-scanni
 | `SCANNER_DOCKER_HOST`           | `tcp://localhost:2375`   | Docker Engine URL |
 | `SCANNER_MICROSCANNER_TOKEN`    |                          | A token issued by Aqua Security for using the MicroScanner. |
 | `SCANNER_MICROSCANNER_OPTIONS`  | `--continue-on-failure --full-output` | Additional options passed as CLI arguments to the MicroScanner. |
-| `SCANNER_STORE_DRIVER`          | `redis`                  | A driver used to store scan requests and reports. |
 | `SCANNER_STORE_REDIS_URL`       | `redis://localhost:6379`            | Redis server URL in Redis URI scheme for a redis store. |
 | `SCANNER_STORE_REDIS_NAMESPACE` | `harbor.scanner.microscanner:store` | A namespace for keys in a redis store. |
 | `SCANNER_STORE_REDIS_POOL_MAX_ACTIVE` | 5 | The max number of connections allocated by the pool for a redis store. |

--- a/cmd/scanner-microscanner/main.go
+++ b/cmd/scanner-microscanner/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/docker"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/etc"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/http/api/v1"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job/work"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/microscanner"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model"
-	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store/redis"
 	log "github.com/sirupsen/logrus"
 	"net/http"
@@ -34,7 +32,7 @@ func main() {
 	wrapper := microscanner.NewWrapper(cfg.MicroScanner)
 	transformer := model.NewTransformer()
 
-	dataStore, err := GetDataStore(cfg)
+	dataStore, err := redis.NewDataStore(cfg.RedisStore)
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}
@@ -52,14 +50,5 @@ func main() {
 	err = http.ListenAndServe(cfg.APIAddr, apiHandler)
 	if err != nil && err != http.ErrServerClosed {
 		log.Fatalf("Error: %v", err)
-	}
-}
-
-func GetDataStore(cfg *etc.Config) (store.DataStore, error) {
-	switch cfg.StoreDriver {
-	case etc.StoreDriverRedis:
-		return redis.NewDataStore(cfg.RedisStore)
-	default:
-		return nil, fmt.Errorf("unrecognized store type: %s", cfg.StoreDriver)
 	}
 }

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -6,15 +6,12 @@ import (
 )
 
 const (
-	StoreDriverRedis = "redis"
-
 	defaultRedisURL = "redis://localhost:6379"
 )
 
 type Config struct {
 	APIAddr      string
 	RegistryURL  string
-	StoreDriver  string
 	MicroScanner *MicroScannerConfig
 	RedisStore   *RedisStoreConfig
 	JobQueue     *JobQueueConfig
@@ -46,8 +43,7 @@ type PoolConfig struct {
 
 func GetConfig() (*Config, error) {
 	cfg := &Config{
-		APIAddr:     ":8080",
-		StoreDriver: StoreDriverRedis,
+		APIAddr: ":8080",
 		MicroScanner: &MicroScannerConfig{
 			DockerHost: "tcp://localhost:2375",
 			Options:    "--continue-on-failure --full-output",
@@ -83,14 +79,10 @@ func GetConfig() (*Config, error) {
 		cfg.RegistryURL = registryURL
 	}
 
-	if driver, ok := os.LookupEnv("SCANNER_STORE_DRIVER"); ok {
-		cfg.StoreDriver = driver
-	}
-
 	if microScannerToken, ok := os.LookupEnv("SCANNER_MICROSCANNER_TOKEN"); ok {
 		cfg.MicroScanner.Token = microScannerToken
 	} else {
-		return nil, errors.New("SCANNER_MICROSCANNER_TOKEN not specified")
+		return nil, errors.New("env SCANNER_MICROSCANNER_TOKEN not set")
 	}
 
 	if options, ok := os.LookupEnv("SCANNER_MICROSCANNER_OPTIONS"); ok {

--- a/pkg/etc/config_test.go
+++ b/pkg/etc/config_test.go
@@ -1,0 +1,74 @@
+package etc
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestGetConfig(t *testing.T) {
+
+	testCases := []struct {
+		Name string
+
+		Envs map[string]string
+
+		ExpectedConfig *Config
+		ExpectedError  error
+	}{
+		{
+			Name:          "Should return error when token is not set",
+			ExpectedError: errors.New("env SCANNER_MICROSCANNER_TOKEN not set"),
+		},
+		{
+			Name: "Should return default config",
+			Envs: map[string]string{"SCANNER_MICROSCANNER_TOKEN": "s3cret"},
+			ExpectedConfig: &Config{
+				APIAddr: ":8080",
+				MicroScanner: &MicroScannerConfig{
+					DockerHost: "tcp://localhost:2375",
+					Options:    "--continue-on-failure --full-output",
+					Token:      "s3cret",
+				},
+				RedisStore: &RedisStoreConfig{
+					RedisURL:  defaultRedisURL,
+					Namespace: "harbor.scanner.microscanner:store",
+					Pool: &PoolConfig{
+						MaxActive: 5,
+						MaxIdle:   5,
+					},
+				},
+				JobQueue: &JobQueueConfig{
+					RedisURL:          defaultRedisURL,
+					Namespace:         "harbor.scanner.microscanner:job-queue",
+					WorkerConcurrency: 1,
+					Pool: &PoolConfig{
+						MaxActive: 5,
+						MaxIdle:   5,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			setenvs(t, tc.Envs)
+			cfg, err := GetConfig()
+			assert.Equal(t, tc.ExpectedError, err)
+			assert.Equal(t, tc.ExpectedConfig, cfg)
+		})
+	}
+
+}
+
+func setenvs(t *testing.T, envs map[string]string) {
+	t.Helper()
+	os.Clearenv()
+	for key, value := range envs {
+		err := os.Setenv(key, value)
+		require.NoError(t, err)
+	}
+}

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"net/http"
@@ -29,8 +28,7 @@ const (
 	pathScanReport       = "/scan/{scanRequestID}/report"
 	pathVarScanRequestID = "scanRequestID"
 
-	fieldScanJob       = "scan_job"
-	fieldScanRequestID = "scan_request_id"
+	fieldScanJob = "scan_job"
 )
 
 type requestHandler struct {
@@ -95,36 +93,37 @@ func (h *requestHandler) AcceptScanRequest(res http.ResponseWriter, req *http.Re
 		return
 	}
 
-	reqLog := log.WithField(fieldScanRequestID, scanRequest.ID)
-
 	if validationError := h.ValidateScanRequest(scanRequest); validationError != nil {
-		reqLog.Errorf("Error while validating scan request: %s", validationError.Message)
+		log.Errorf("Error while validating scan request: %s", validationError.Message)
 		h.SendJSONError(res, *validationError)
 		return
 	}
 
 	scanJob, err := h.jobQueue.EnqueueScanJob(scanRequest)
 	if err != nil {
-		reqLog.WithError(err).Error("Error while enqueuing scan job")
+		log.WithError(err).Error("Error while enqueuing scan job")
 		h.SendJSONError(res, harbor.Error{
 			HTTPCode: http.StatusInternalServerError,
 			Message:  fmt.Sprintf("enqueuing scan job: %s", err.Error()),
 		})
 		return
 	}
-	reqLog.WithField(fieldScanJob, scanJob.ID).Debug("Scan job enqueued successfully")
+	log.WithField(fieldScanJob, scanJob.ID).Debug("Scan job enqueued successfully")
 
 	res.WriteHeader(http.StatusAccepted)
+	res.Header().Set(HeaderContentType, mimeTypeMetadata)
+	err = json.NewEncoder(res).Encode(harbor.ScanResponse{ID: scanJob.ID})
+	if err != nil {
+		log.Errorf("Error while marshalling scan response: %v", err)
+		h.SendJSONError(res, harbor.Error{
+			HTTPCode: http.StatusInternalServerError,
+			Message:  fmt.Sprintf("marshaling scan response: %s", err.Error()),
+		})
+		return
+	}
 }
 
 func (h *requestHandler) ValidateScanRequest(req harbor.ScanRequest) *harbor.Error {
-	if req.ID == "" {
-		return &harbor.Error{
-			HTTPCode: http.StatusUnprocessableEntity,
-			Message:  "missing id",
-		}
-	}
-
 	if req.Registry.URL == "" {
 		return &harbor.Error{
 			HTTPCode: http.StatusUnprocessableEntity,
@@ -160,50 +159,41 @@ func (h *requestHandler) ValidateScanRequest(req harbor.ScanRequest) *harbor.Err
 func (h *requestHandler) GetScanReport(res http.ResponseWriter, req *http.Request) {
 	log.Debug("Get scan report request received")
 	vars := mux.Vars(req)
-	scanRequestID, ok := vars[pathVarScanRequestID]
+	scanJobID, ok := vars[pathVarScanRequestID]
 	if !ok {
 		http.Error(res, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
-	scanID, err := uuid.Parse(scanRequestID)
-	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
-			fieldScanRequestID: scanRequestID,
-		}).Error("Error while parsing scan request ID")
-		h.SendInternalServerError(res)
-		return
-	}
-
-	scanJob, err := h.jobQueue.GetScanJob(scanID)
+	scanJob, err := h.dataStore.GetScanJob(scanJobID)
 	if scanJob == nil {
-		log.Errorf("Cannot find scan job for the given scan request ID: %v", scanID)
+		log.Errorf("Cannot find scan job: %v", scanJobID)
 		http.Error(res, "Not Found", http.StatusNotFound)
 		return
 	}
 
 	if scanJob.Status == job.Queued || scanJob.Status == job.Pending {
-		log.Debugf("Scan job has not finished yet: %v", scanJob)
+		log.Debugf("Scan job has not finished yet: %v (%v)", scanJob.ID, scanJob.Status)
 		res.Header().Set(headerRefreshAfter, "15")
 		res.WriteHeader(http.StatusFound)
 		return
 	}
 
 	if scanJob.Status == job.Failed {
-		log.Errorf("Scan job failed for the given scan request ID: %v", scanID)
+		log.Errorf("Scan job failed: %v", scanJobID)
 		h.SendInternalServerError(res)
 		return
 	}
 
 	if scanJob.Status != job.Finished {
-		log.Errorf("Unexpected scan job status: %v", scanJob)
+		log.Errorf("Unexpected scan job status: %v (%v)", scanJob.ID, scanJob.Status)
 		h.SendInternalServerError(res)
 		return
 	}
 
-	scanReports, err := h.dataStore.GetScanReports(scanID)
+	scanReports, err := h.dataStore.GetScanReports(scanJobID)
 	if scanReports == nil {
-		log.Errorf("Cannot find scan reports for the given scan request ID: %v", scanID)
+		log.Errorf("Cannot find scan reports for the given scan request ID: %v", scanJobID)
 		h.SendInternalServerError(res)
 		return
 	}

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -19,6 +19,7 @@ const (
 
 	mimeTypeMetadata                  = "application/vnd.scanner.adapter.metadata+json; version=1.0"
 	mimeTypeScanRequest               = "application/vnd.scanner.adapter.scan.request+json; version=1.0"
+	mimeTypeScanResponse              = "application/vnd.scanner.adapter.scan.response+json; version=1.0"
 	mimeTypeHarborVulnerabilityReport = "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
 	mimeTypeMicroScannerReport        = "application/vnd.scanner.adapter.vuln.report.raw"
 
@@ -111,7 +112,7 @@ func (h *requestHandler) AcceptScanRequest(res http.ResponseWriter, req *http.Re
 	log.WithField(fieldScanJobID, scanJob.ID).Debug("Scan job enqueued successfully")
 
 	res.WriteHeader(http.StatusAccepted)
-	res.Header().Set(HeaderContentType, mimeTypeMetadata)
+	res.Header().Set(HeaderContentType, mimeTypeScanResponse)
 	err = json.NewEncoder(res).Encode(harbor.ScanResponse{ID: scanJob.ID})
 	if err != nil {
 		log.Errorf("Error while marshalling scan response: %v", err)

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/mocks"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
-	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -169,9 +168,8 @@ func TestRequestHandler_ValidateScanRequest(t *testing.T) {
 		ExpectedError *harbor.Error
 	}{
 		{
-			Name: "Should return error when Registry URL is blank",
-			Request: harbor.ScanRequest{
-			},
+			Name:    "Should return error when Registry URL is blank",
+			Request: harbor.ScanRequest{},
 			ExpectedError: &harbor.Error{
 				HTTPCode: http.StatusUnprocessableEntity,
 				Message:  "missing registry.url",
@@ -415,16 +413,18 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			},
 			DataStoreExpectation: []*mocks.Expectation{
 				{
-					MethodName:      "GetScanJob",
-					Arguments:       []interface{}{scanRequestID},
-					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
-				},
-				{
-					MethodName: "GetScanReports",
+					MethodName: "GetScanJob",
 					Arguments:  []interface{}{scanRequestID},
-					ReturnArguments: []interface{}{&store.ScanReports{
-						HarborVulnerabilityReport: harborReport,
-					}, nil},
+					ReturnArguments: []interface{}{
+						&job.ScanJob{
+							ID:     scanRequestID,
+							Status: job.Finished,
+							Reports: &job.ScanReports{
+								HarborVulnerabilityReport: harborReport,
+							},
+						},
+						nil,
+					},
 				},
 			},
 			Response: Response{
@@ -441,16 +441,18 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			},
 			DataStoreExpectation: []*mocks.Expectation{
 				{
-					MethodName:      "GetScanJob",
-					Arguments:       []interface{}{scanRequestID},
-					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
-				},
-				{
-					MethodName: "GetScanReports",
+					MethodName: "GetScanJob",
 					Arguments:  []interface{}{scanRequestID},
-					ReturnArguments: []interface{}{&store.ScanReports{
-						HarborVulnerabilityReport: harborReport,
-					}, nil},
+					ReturnArguments: []interface{}{
+						&job.ScanJob{
+							ID:     scanRequestID,
+							Status: job.Finished,
+							Reports: &job.ScanReports{
+								HarborVulnerabilityReport: harborReport,
+							},
+						},
+						nil,
+					},
 				},
 			},
 			Response: Response{
@@ -469,16 +471,17 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			},
 			DataStoreExpectation: []*mocks.Expectation{
 				{
-					MethodName:      "GetScanJob",
-					Arguments:       []interface{}{scanRequestID},
-					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
-				},
-				{
-					MethodName: "GetScanReports",
+					MethodName: "GetScanJob",
 					Arguments:  []interface{}{scanRequestID},
-					ReturnArguments: []interface{}{&store.ScanReports{
-						MicroScannerReport: microScannerReport,
-					}, nil},
+					ReturnArguments: []interface{}{
+						&job.ScanJob{
+							ID:     scanRequestID,
+							Status: job.Finished,
+							Reports: &job.ScanReports{
+								MicroScannerReport: microScannerReport,
+							},
+						},
+						nil},
 				},
 			},
 			Response: Response{

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -25,12 +24,6 @@ type Request struct {
 type Response struct {
 	Code int
 	Body string
-}
-
-type Expectation struct {
-	MethodName      string
-	Arguments       []interface{}
-	ReturnArguments []interface{}
 }
 
 func TestRequestHandler_GetMetadata(t *testing.T) {
@@ -74,7 +67,6 @@ func TestRequestHandler_GetMetadata(t *testing.T) {
 
 func TestRequestHandler_AcceptScanRequest(t *testing.T) {
 	scanRequest := harbor.ScanRequest{
-		ID: "ABC",
 		Registry: harbor.Registry{
 			URL:           "https://core.harbor.domain",
 			Authorization: "Bearer: SECRET",
@@ -177,17 +169,8 @@ func TestRequestHandler_ValidateScanRequest(t *testing.T) {
 		ExpectedError *harbor.Error
 	}{
 		{
-			Name:    "Should return error when ID is blank",
-			Request: harbor.ScanRequest{},
-			ExpectedError: &harbor.Error{
-				HTTPCode: http.StatusUnprocessableEntity,
-				Message:  "missing id",
-			},
-		},
-		{
 			Name: "Should return error when Registry URL is blank",
 			Request: harbor.ScanRequest{
-				ID: uuid.New().String(),
 			},
 			ExpectedError: &harbor.Error{
 				HTTPCode: http.StatusUnprocessableEntity,
@@ -197,7 +180,6 @@ func TestRequestHandler_ValidateScanRequest(t *testing.T) {
 		{
 			Name: "Should return error when Registry URL is invalid",
 			Request: harbor.ScanRequest{
-				ID: uuid.New().String(),
 				Registry: harbor.Registry{
 					URL: "INVALID URL",
 				},
@@ -210,7 +192,6 @@ func TestRequestHandler_ValidateScanRequest(t *testing.T) {
 		{
 			Name: "Should return error when artifact repository is blank",
 			Request: harbor.ScanRequest{
-				ID: uuid.New().String(),
 				Registry: harbor.Registry{
 					URL: "https://core.harbor.domain",
 				},
@@ -223,7 +204,6 @@ func TestRequestHandler_ValidateScanRequest(t *testing.T) {
 		{
 			Name: "Should return error when artifact digest is blank",
 			Request: harbor.ScanRequest{
-				ID: uuid.New().String(),
 				Registry: harbor.Registry{
 					URL: "https://core.harbor.domain",
 				},
@@ -248,8 +228,7 @@ func TestRequestHandler_ValidateScanRequest(t *testing.T) {
 }
 
 func TestRequestHandler_GetScanReport(t *testing.T) {
-
-	scanRequestID := uuid.New()
+	scanRequestID := "job:123"
 	harborReport := &harbor.VulnerabilityReport{
 		Severity: harbor.SevHigh,
 		Vulnerabilities: []*harbor.VulnerabilityItem{
@@ -350,24 +329,25 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 
 	var nilScanJob *job.ScanJob
 
-	data := []struct {
+	testCases := []struct {
 		Scenario             string
 		Skip                 bool
 		Request              Request
 		Response             Response
-		JobQueueExpectation  *Expectation
-		DataStoreExpectation *Expectation
+		DataStoreExpectation []*mocks.Expectation
 	}{
 		{
 			Scenario: "Should return 404 Not Found when scan job is nil",
 			Request: Request{
 				Method: http.MethodGet,
-				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{nilScanJob, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{nilScanJob, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusNotFound,
@@ -377,12 +357,14 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			Scenario: fmt.Sprintf("Should return 302 Found status when scan job is %s", job.Queued),
 			Request: Request{
 				Method: http.MethodGet,
-				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&job.ScanJob{Status: job.Queued}, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Queued}, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusFound,
@@ -392,12 +374,14 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			Scenario: fmt.Sprintf("Should return 302 Found status when scan job is %s", job.Pending),
 			Request: Request{
 				Method: http.MethodGet,
-				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&job.ScanJob{Status: job.Pending}, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Pending}, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusFound,
@@ -407,12 +391,14 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			Scenario: fmt.Sprintf("Should return 500 Internal Server Error when scan job is %s", job.Failed),
 			Request: Request{
 				Method: http.MethodGet,
-				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&job.ScanJob{Status: job.Failed}, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Failed}, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusInternalServerError,
@@ -422,22 +408,24 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			Scenario: "Should return HarborVulnerabilityReport when report MIME type is specified",
 			Request: Request{
 				Method: http.MethodGet,
-				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 				Headers: map[string][]string{
 					headerAccept: {mimeTypeHarborVulnerabilityReport},
 				},
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
-			},
-			DataStoreExpectation: &Expectation{
-				MethodName: "GetScanReports",
-				Arguments:  []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&store.ScanReports{
-					HarborVulnerabilityReport: harborReport,
-				}, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
+				},
+				{
+					MethodName: "GetScanReports",
+					Arguments:  []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&store.ScanReports{
+						HarborVulnerabilityReport: harborReport,
+					}, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusOK,
@@ -448,20 +436,22 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			Scenario: "Should return HarborVulnerabilityReport when report MIME type is not specified",
 			Request: Request{
 				Method:  http.MethodGet,
-				Target:  fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target:  fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 				Headers: map[string][]string{},
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
-			},
-			DataStoreExpectation: &Expectation{
-				MethodName: "GetScanReports",
-				Arguments:  []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&store.ScanReports{
-					HarborVulnerabilityReport: harborReport,
-				}, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
+				},
+				{
+					MethodName: "GetScanReports",
+					Arguments:  []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&store.ScanReports{
+						HarborVulnerabilityReport: harborReport,
+					}, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusOK,
@@ -472,22 +462,24 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			Scenario: "Should return MicroScannerReport",
 			Request: Request{
 				Method: http.MethodGet,
-				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID.String()),
+				Target: fmt.Sprintf("/api/v1/scan/%s/report", scanRequestID),
 				Headers: map[string][]string{
 					headerAccept: {mimeTypeMicroScannerReport},
 				},
 			},
-			JobQueueExpectation: &Expectation{
-				MethodName:      "GetScanJob",
-				Arguments:       []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
-			},
-			DataStoreExpectation: &Expectation{
-				MethodName: "GetScanReports",
-				Arguments:  []interface{}{scanRequestID},
-				ReturnArguments: []interface{}{&store.ScanReports{
-					MicroScannerReport: microScannerReport,
-				}, nil},
+			DataStoreExpectation: []*mocks.Expectation{
+				{
+					MethodName:      "GetScanJob",
+					Arguments:       []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&job.ScanJob{Status: job.Finished}, nil},
+				},
+				{
+					MethodName: "GetScanReports",
+					Arguments:  []interface{}{scanRequestID},
+					ReturnArguments: []interface{}{&store.ScanReports{
+						MicroScannerReport: microScannerReport,
+					}, nil},
+				},
 			},
 			Response: Response{
 				Code: http.StatusOK,
@@ -496,7 +488,7 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 		},
 	}
 
-	for _, td := range data {
+	for _, td := range testCases {
 		t.Run(td.Scenario, func(t *testing.T) {
 			if td.Skip {
 				t.Skip()
@@ -505,15 +497,7 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 			jobQueue := mocks.NewJobQueue()
 			dataStore := mocks.NewDataStore()
 
-			if expectation := td.JobQueueExpectation; expectation != nil {
-				jobQueue.On(expectation.MethodName, expectation.Arguments...).
-					Return(expectation.ReturnArguments...)
-			}
-
-			if expectation := td.DataStoreExpectation; expectation != nil {
-				dataStore.On(expectation.MethodName, expectation.Arguments...).
-					Return(expectation.ReturnArguments...)
-			}
+			mocks.ApplyExpectations(t, dataStore, td.DataStoreExpectation...)
 
 			// and
 			handler := NewAPIHandler(jobQueue, dataStore)

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -107,6 +107,7 @@ func TestRequestHandler_AcceptScanRequest(t *testing.T) {
 				ReturnArguments: []interface{}{&job.ScanJob{ID: "job:123"}, nil},
 			},
 			ExpectedHTTPStatus: http.StatusAccepted,
+			ExpectedResponse:   `{"id": "job:123"}`,
 		},
 		{
 			Name:            "Should return error when enqueuing scan job fails",

--- a/pkg/job/queue.go
+++ b/pkg/job/queue.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
+	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
 )
 
 type ScanJobStatus int
@@ -17,12 +18,23 @@ func (s ScanJobStatus) String() string {
 	return [...]string{"Queued", "Pending", "Finished", "Failed"}[s]
 }
 
+// ScanReports represents scan reports in MicroScanner and Harbor format.
+type ScanReports struct {
+	HarborVulnerabilityReport *harbor.VulnerabilityReport `json:"harbor_vulnerability_report"`
+	MicroScannerReport        *microscanner.ScanReport    `json:"micro_scanner_report"`
+}
+
+// ScanJob represents a task of handling a given ScanRequest.
 type ScanJob struct {
-	ID     string        `json:"id"`
-	Status ScanJobStatus `json:"status"`
+	ID      string        `json:"id"`
+	Status  ScanJobStatus `json:"status"`
+	Reports *ScanReports  `json:"reports"`
+	// TODO Add Artifact field
+	// TODO Add Error field
 }
 
 // Queue manages execution of ScanJobs.
+// TODO(refactor) Split Queue into ScanEnqueuer and ScanWorker
 type Queue interface {
 	// Start starts this queue.
 	Start()

--- a/pkg/job/queue.go
+++ b/pkg/job/queue.go
@@ -2,7 +2,6 @@ package job
 
 import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
-	"github.com/google/uuid"
 )
 
 type ScanJobStatus int
@@ -31,6 +30,4 @@ type Queue interface {
 	Stop()
 	// EnqueueScanJob enqueues a ScanJob for the given ScanRequest.
 	EnqueueScanJob(sr harbor.ScanRequest) (*ScanJob, error)
-	// GetScanJob returns a ScanJob associated with the given scan request identifier.
-	GetScanJob(scanID uuid.UUID) (*ScanJob, error)
 }

--- a/pkg/job/work/queue.go
+++ b/pkg/job/work/queue.go
@@ -86,7 +86,7 @@ func (wq *workQueue) EnqueueScanJob(sr harbor.ScanRequest) (*job.ScanJob, error)
 		Status: job.Queued,
 	}
 
-	err = wq.dataStore.SaveScanJob(scanJob.ID, scanJob)
+	err = wq.dataStore.SaveScanJob(scanJob)
 	if err != nil {
 		return nil, fmt.Errorf("saving scan job %v", err)
 	}

--- a/pkg/job/work/queue_test.go
+++ b/pkg/job/work/queue_test.go
@@ -1,11 +1,9 @@
 package work
 
 import (
-	"fmt"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/mocks"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/gocraft/work"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -13,9 +11,7 @@ import (
 func TestWorkQueue_ExecuteScanJob(t *testing.T) {
 	scanner := mocks.NewScanner()
 
-	scanID := uuid.New()
 	scanRequest := harbor.ScanRequest{
-		ID: scanID.String(),
 		Registry: harbor.Registry{
 			URL: "docker.io",
 		},
@@ -24,8 +20,7 @@ func TestWorkQueue_ExecuteScanJob(t *testing.T) {
 			Digest:     "sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
 		},
 	}
-	scanRequestJSON := fmt.Sprintf(`{
-  "id": "%s",
+	scanRequestJSON := `{
   "registry": {
     "url": "docker.io"
   },
@@ -33,16 +28,17 @@ func TestWorkQueue_ExecuteScanJob(t *testing.T) {
     "repository": "library/mongo",
     "digest": "sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e"
   }
-}`, scanID.String())
+}`
 
 	job := &work.Job{
+		ID: "job:123",
 		Args: map[string]interface{}{
 			"scanner":      scanner,
 			"scan_request": scanRequestJSON,
 		},
 	}
 
-	scanner.On("Scan", scanRequest).Return(nil)
+	scanner.On("Scan", "job:123", scanRequest).Return(nil)
 
 	queue := &workQueue{}
 

--- a/pkg/microscanner/scanner.go
+++ b/pkg/microscanner/scanner.go
@@ -15,7 +15,6 @@ import (
 )
 
 // Scanner wraps the Scan method.
-// TODO Rename to ScannerManager
 type Scanner interface {
 	Scan(scanJobID string, request harbor.ScanRequest) error
 }
@@ -36,12 +35,12 @@ func NewScanner(authorizer docker.Authorizer, wrapper Wrapper, transformer model
 	}
 }
 
-func (s *scanner) Scan(scanJobID string,req harbor.ScanRequest) error {
+func (s *scanner) Scan(scanJobID string, req harbor.ScanRequest) error {
 
 	err := s.scan(scanJobID, req)
 	if err != nil {
 		log.Errorf("Scan failed: %v", err)
-		err = s.dataStore.UpdateScanJobStatus(scanJobID, job.Pending, job.Failed)
+		err = s.dataStore.UpdateStatus(scanJobID, job.Pending, job.Failed)
 		if err != nil {
 			return fmt.Errorf("updating scan job as failed: %v", err)
 		}
@@ -50,7 +49,7 @@ func (s *scanner) Scan(scanJobID string,req harbor.ScanRequest) error {
 }
 
 func (s *scanner) scan(scanID string, req harbor.ScanRequest) error {
-	err := s.dataStore.UpdateScanJobStatus(scanID, job.Queued, job.Pending)
+	err := s.dataStore.UpdateStatus(scanID, job.Queued, job.Pending)
 	if err != nil {
 		return fmt.Errorf("updating scan job status: %v", err)
 	}
@@ -83,7 +82,7 @@ func (s *scanner) scan(scanID string, req harbor.ScanRequest) error {
 		return fmt.Errorf("transforming microscanner report to harbor vulnerability report: %v", err)
 	}
 
-	err = s.dataStore.SaveScanReports(scanID, &store.ScanReports{
+	err = s.dataStore.UpdateReports(scanID, job.ScanReports{
 		MicroScannerReport:        microScannerReport,
 		HarborVulnerabilityReport: harborVulnerabilityReport,
 	})
@@ -92,7 +91,7 @@ func (s *scanner) scan(scanID string, req harbor.ScanRequest) error {
 		return fmt.Errorf("saving scan reports: %v", err)
 	}
 
-	err = s.dataStore.UpdateScanJobStatus(scanID, job.Pending, job.Finished)
+	err = s.dataStore.UpdateStatus(scanID, job.Pending, job.Finished)
 	if err != nil {
 		return fmt.Errorf("updating scan job status: %v", err)
 	}

--- a/pkg/microscanner/scanner_test.go
+++ b/pkg/microscanner/scanner_test.go
@@ -1,13 +1,11 @@
 package microscanner
 
 import (
-	"errors"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/mocks"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -20,9 +18,8 @@ func TestScanner_Scan(t *testing.T) {
 	configFileName := filepath.Join(tmpDir, "config.json")
 
 	require.NoError(t, err)
-	scanID := uuid.New()
+	scanID := "job:123"
 	scanRequest := harbor.ScanRequest{
-		ID: scanID.String(),
 		Registry: harbor.Registry{
 			URL: "https://core.harbor.domain:433",
 		},
@@ -93,13 +90,6 @@ func TestScanner_Scan(t *testing.T) {
 			},
 			ExpectedError: nil,
 		},
-		{
-			Name: "Should return error when scan ID is not a valid UUID",
-			ScanRequest: harbor.ScanRequest{
-				ID: "INVALID_UUID",
-			},
-			ExpectedError: errors.New("parsing scan request ID: invalid UUID length: 12"),
-		},
 	}
 
 	for _, tc := range testCases {
@@ -120,7 +110,7 @@ func TestScanner_Scan(t *testing.T) {
 
 			scanner := NewScanner(authorizer, wrapper, transformer, dataStore)
 
-			err := scanner.Scan(tc.ScanRequest)
+			err := scanner.Scan(scanID, tc.ScanRequest)
 			assert.Equal(t, tc.ExpectedError, err)
 
 			authorizer.AssertExpectations(t)

--- a/pkg/microscanner/scanner_test.go
+++ b/pkg/microscanner/scanner_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/mocks"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
-	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -30,7 +29,7 @@ func TestScanner_Scan(t *testing.T) {
 	}
 	harborReport := &harbor.VulnerabilityReport{}
 	microScannerReport := &microscanner.ScanReport{}
-	scanReports := &store.ScanReports{
+	scanReports := &job.ScanReports{
 		HarborVulnerabilityReport: harborReport,
 		MicroScannerReport:        microScannerReport,
 	}
@@ -42,7 +41,7 @@ func TestScanner_Scan(t *testing.T) {
 		ScanRequest            harbor.ScanRequest
 		MicroScannerReport     *microscanner.ScanReport
 		HarborReport           *harbor.VulnerabilityReport
-		ScanReports            *store.ScanReports
+		ScanReports            *job.ScanReports
 		AuthorizerExpectation  *mocks.Expectation
 		WrapperExpectation     *mocks.Expectation
 		TransformerExpectation *mocks.Expectation
@@ -73,17 +72,17 @@ func TestScanner_Scan(t *testing.T) {
 			},
 			DataStoreExpectations: []*mocks.Expectation{
 				{
-					MethodName:      "UpdateScanJobStatus",
+					MethodName:      "UpdateStatus",
 					Arguments:       []interface{}{scanID, job.Queued, job.Pending},
 					ReturnArguments: []interface{}{nil},
 				},
 				{
-					MethodName:      "SaveScanReports",
-					Arguments:       []interface{}{scanID, scanReports},
+					MethodName:      "UpdateReports",
+					Arguments:       []interface{}{scanID, *scanReports},
 					ReturnArguments: []interface{}{nil},
 				},
 				{
-					MethodName:      "UpdateScanJobStatus",
+					MethodName:      "UpdateStatus",
 					Arguments:       []interface{}{scanID, job.Pending, job.Finished},
 					ReturnArguments: []interface{}{nil},
 				},

--- a/pkg/mocks/scanner.go
+++ b/pkg/mocks/scanner.go
@@ -13,7 +13,7 @@ func NewScanner() *ScannerMock {
 	return &ScannerMock{}
 }
 
-func (m *ScannerMock) Scan(req harbor.ScanRequest) error {
-	args := m.Called(req)
+func (m *ScannerMock) Scan(scanJobID string, req harbor.ScanRequest) error {
+	args := m.Called(scanJobID, req)
 	return args.Error(0)
 }

--- a/pkg/mocks/store.go
+++ b/pkg/mocks/store.go
@@ -3,7 +3,6 @@ package mocks
 import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -15,27 +14,27 @@ func NewDataStore() *DataStoreMock {
 	return &DataStoreMock{}
 }
 
-func (m *DataStoreMock) SaveScanJob(scanID uuid.UUID, scanJob *job.ScanJob) error {
+func (m *DataStoreMock) SaveScanJob(scanID string, scanJob *job.ScanJob) error {
 	args := m.Called(scanID, scanJob)
 	return args.Error(0)
 }
 
-func (m *DataStoreMock) GetScanJob(scanID uuid.UUID) (*job.ScanJob, error) {
+func (m *DataStoreMock) GetScanJob(scanID string) (*job.ScanJob, error) {
 	args := m.Called(scanID)
 	return args.Get(0).(*job.ScanJob), args.Error(1)
 }
 
-func (m *DataStoreMock) UpdateScanJobStatus(scanID uuid.UUID, currentStatus, newStatus job.ScanJobStatus) error {
+func (m *DataStoreMock) UpdateScanJobStatus(scanID string, currentStatus, newStatus job.ScanJobStatus) error {
 	args := m.Called(scanID, currentStatus, newStatus)
 	return args.Error(0)
 }
 
-func (m *DataStoreMock) SaveScanReports(scanID uuid.UUID, scanReports *store.ScanReports) error {
+func (m *DataStoreMock) SaveScanReports(scanID string, scanReports *store.ScanReports) error {
 	args := m.Called(scanID, scanReports)
 	return args.Error(0)
 }
 
-func (m *DataStoreMock) GetScanReports(scanID uuid.UUID) (*store.ScanReports, error) {
+func (m *DataStoreMock) GetScanReports(scanID string) (*store.ScanReports, error) {
 	args := m.Called(scanID)
 	return args.Get(0).(*store.ScanReports), args.Error(1)
 }

--- a/pkg/mocks/store.go
+++ b/pkg/mocks/store.go
@@ -2,7 +2,6 @@ package mocks
 
 import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job"
-	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/store"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,27 +13,22 @@ func NewDataStore() *DataStoreMock {
 	return &DataStoreMock{}
 }
 
-func (m *DataStoreMock) SaveScanJob(scanID string, scanJob *job.ScanJob) error {
-	args := m.Called(scanID, scanJob)
+func (m *DataStoreMock) SaveScanJob(scanJob *job.ScanJob) error {
+	args := m.Called(scanJob)
 	return args.Error(0)
 }
 
-func (m *DataStoreMock) GetScanJob(scanID string) (*job.ScanJob, error) {
-	args := m.Called(scanID)
+func (m *DataStoreMock) GetScanJob(scanJobID string) (*job.ScanJob, error) {
+	args := m.Called(scanJobID)
 	return args.Get(0).(*job.ScanJob), args.Error(1)
 }
 
-func (m *DataStoreMock) UpdateScanJobStatus(scanID string, currentStatus, newStatus job.ScanJobStatus) error {
-	args := m.Called(scanID, currentStatus, newStatus)
+func (m *DataStoreMock) UpdateStatus(scanJobID string, currentStatus, newStatus job.ScanJobStatus) error {
+	args := m.Called(scanJobID, currentStatus, newStatus)
 	return args.Error(0)
 }
 
-func (m *DataStoreMock) SaveScanReports(scanID string, scanReports *store.ScanReports) error {
-	args := m.Called(scanID, scanReports)
+func (m *DataStoreMock) UpdateReports(scanJobID string, reports job.ScanReports) error {
+	args := m.Called(scanJobID, reports)
 	return args.Error(0)
-}
-
-func (m *DataStoreMock) GetScanReports(scanID string) (*store.ScanReports, error) {
-	args := m.Called(scanID)
-	return args.Get(0).(*store.ScanReports), args.Error(1)
 }

--- a/pkg/model/harbor/model.go
+++ b/pkg/model/harbor/model.go
@@ -25,9 +25,12 @@ type Artifact struct {
 }
 
 type ScanRequest struct {
-	ID       string   `json:"id"`
 	Registry Registry `json:"registry"`
 	Artifact Artifact `json:"artifact"`
+}
+
+type ScanResponse struct {
+	ID string `json:"id"`
 }
 
 type VulnerabilityReport struct {

--- a/pkg/store/redis/store_integration_test.go
+++ b/pkg/store/redis/store_integration_test.go
@@ -53,9 +53,9 @@ func TestRedisStore_ScanCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Should save and get ScanJob", func(t *testing.T) {
-		scanID := uuid.New()
+		scanID := uuid.New().String()
 		err := dataStore.SaveScanJob(scanID, &job.ScanJob{
-			ID:     scanID.String(),
+			ID:     scanID,
 			Status: job.Queued,
 		})
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestRedisStore_ScanCRUD(t *testing.T) {
 		j, err := dataStore.GetScanJob(scanID)
 		require.NoError(t, err)
 		assert.Equal(t, &job.ScanJob{
-			ID:     scanID.String(),
+			ID:     scanID,
 			Status: job.Queued,
 		}, j)
 
@@ -75,13 +75,13 @@ func TestRedisStore_ScanCRUD(t *testing.T) {
 
 		j, err = dataStore.GetScanJob(scanID)
 		assert.Equal(t, &job.ScanJob{
-			ID:     scanID.String(),
+			ID:     scanID,
 			Status: job.Pending,
 		}, j)
 	})
 
 	t.Run("Should save and get ScanReports", func(t *testing.T) {
-		scanID := uuid.New()
+		scanID := uuid.New().String()
 		scanReports := &store.ScanReports{
 			HarborVulnerabilityReport: &harbor.VulnerabilityReport{
 				Severity: harbor.SevHigh,

--- a/pkg/store/redis/store_integration_test.go
+++ b/pkg/store/redis/store_integration_test.go
@@ -52,29 +52,29 @@ func TestRedisStore_ScanCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Should save and get ScanJob", func(t *testing.T) {
-		scanID := uuid.New().String()
+		scanJobID := uuid.New().String()
 		err := dataStore.SaveScanJob(&job.ScanJob{
-			ID:     scanID,
+			ID:     scanJobID,
 			Status: job.Queued,
 		})
 		require.NoError(t, err)
 
-		j, err := dataStore.GetScanJob(scanID)
+		j, err := dataStore.GetScanJob(scanJobID)
 		require.NoError(t, err)
 		assert.Equal(t, &job.ScanJob{
-			ID:     scanID,
+			ID:     scanJobID,
 			Status: job.Queued,
 		}, j)
 
-		err = dataStore.UpdateStatus(scanID, job.Pending, job.Finished)
+		err = dataStore.UpdateStatus(scanJobID, job.Pending, job.Finished)
 		assert.EqualError(t, err, "expected status Pending but was Queued")
 
-		err = dataStore.UpdateStatus(scanID, job.Queued, job.Pending)
+		err = dataStore.UpdateStatus(scanJobID, job.Queued, job.Pending)
 		require.NoError(t, err)
 
-		j, err = dataStore.GetScanJob(scanID)
+		j, err = dataStore.GetScanJob(scanJobID)
 		assert.Equal(t, &job.ScanJob{
-			ID:     scanID,
+			ID:     scanJobID,
 			Status: job.Pending,
 		}, j)
 
@@ -100,10 +100,10 @@ func TestRedisStore_ScanCRUD(t *testing.T) {
 			},
 		}
 
-		err = dataStore.UpdateReports(scanID, scanReports)
+		err = dataStore.UpdateReports(scanJobID, scanReports)
 		require.NoError(t, err)
 
-		j, err = dataStore.GetScanJob(scanID)
+		j, err = dataStore.GetScanJob(scanJobID)
 		require.NoError(t, err)
 		assert.Equal(t, scanReports, *j.Reports)
 	})

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -4,10 +4,10 @@ import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
-	"github.com/google/uuid"
 )
 
 // ScanReports represents scan reports in MicroScanner and Harbor format.
+// TODO Add as property to ScanJob
 type ScanReports struct {
 	HarborVulnerabilityReport *harbor.VulnerabilityReport `json:"harbor_vulnerability_report"`
 	MicroScannerReport        *microscanner.ScanReport    `json:"micro_scanner_report"`
@@ -16,14 +16,14 @@ type ScanReports struct {
 // DataStore defines methods for saving and retrieving ScanJobs and ScanReports.
 type DataStore interface {
 	// SaveScanJob saves a given ScanJob associated with the given scan identifier.
-	SaveScanJob(scanID uuid.UUID, scanJob *job.ScanJob) error
+	SaveScanJob(scanID string, scanJob *job.ScanJob) error
 	// GetScanJob gets a ScanJob associated with the given scan identifier.
-	GetScanJob(scanID uuid.UUID) (*job.ScanJob, error)
+	GetScanJob(scanID string) (*job.ScanJob, error)
 	// UpdateScanJobStatus updates the status of the ScanJob associated with the given scan identifier.
 	// Returns an error when the actual state of the ScanJob is different then the specified currentStatus.
-	UpdateScanJobStatus(scanID uuid.UUID, currentStatus, newStatus job.ScanJobStatus) error
+	UpdateScanJobStatus(scanID string, currentStatus, newStatus job.ScanJobStatus) error
 	// SaveScanReports saves given ScanReports associated with the given scan identifier.
-	SaveScanReports(scanID uuid.UUID, scanReports *ScanReports) error
+	SaveScanReports(scanID string, scanReports *ScanReports) error
 	// GetScanReports gets ScanReports associated with the given scan identifier.
-	GetScanReports(scanID uuid.UUID) (*ScanReports, error)
+	GetScanReports(scanID string) (*ScanReports, error)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -2,28 +2,17 @@ package store
 
 import (
 	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/job"
-	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/harbor"
-	"github.com/aquasecurity/harbor-scanner-microscanner/pkg/model/microscanner"
 )
 
-// ScanReports represents scan reports in MicroScanner and Harbor format.
-// TODO Add as property to ScanJob
-type ScanReports struct {
-	HarborVulnerabilityReport *harbor.VulnerabilityReport `json:"harbor_vulnerability_report"`
-	MicroScannerReport        *microscanner.ScanReport    `json:"micro_scanner_report"`
-}
-
-// DataStore defines methods for saving and retrieving ScanJobs and ScanReports.
+// DataStore defines methods for persisting ScanJobs.
 type DataStore interface {
-	// SaveScanJob saves a given ScanJob associated with the given scan identifier.
-	SaveScanJob(scanID string, scanJob *job.ScanJob) error
-	// GetScanJob gets a ScanJob associated with the given scan identifier.
-	GetScanJob(scanID string) (*job.ScanJob, error)
-	// UpdateScanJobStatus updates the status of the ScanJob associated with the given scan identifier.
+	// SaveScanJob saves a given ScanJob.
+	SaveScanJob(scanJob *job.ScanJob) error
+	// GetScanJob gets a ScanJob for the specified identifier.
+	GetScanJob(scanJobID string) (*job.ScanJob, error)
+	// UpdateStatus updates the status of the specified ScanJob.
 	// Returns an error when the actual state of the ScanJob is different then the specified currentStatus.
-	UpdateScanJobStatus(scanID string, currentStatus, newStatus job.ScanJobStatus) error
-	// SaveScanReports saves given ScanReports associated with the given scan identifier.
-	SaveScanReports(scanID string, scanReports *ScanReports) error
-	// GetScanReports gets ScanReports associated with the given scan identifier.
-	GetScanReports(scanID string) (*ScanReports, error)
+	UpdateStatus(scanJobID string, currentStatus, newStatus job.ScanJobStatus) error
+	// UpdateScanReports updates the ScanReports of the specified ScanJob.
+	UpdateReports(scanJobID string, reports job.ScanReports) error
 }


### PR DESCRIPTION
After a long debate we agreed that Scanner Adapter is generating an identifier which is then used to fetch ScanReports. Since we're using gocraft/work for scheduling scans, which has a notion of jobs, I've used the job's identifier to fetch the corresponding ScanReport.