### PR TITLE
Return structured errors from GetScanReport handler

### DIFF
--- a/pkg/job/queue.go
+++ b/pkg/job/queue.go
@@ -15,6 +15,9 @@ const (
 )
 
 func (s ScanJobStatus) String() string {
+	if s < 0 || s > 3 {
+		return "Unknown"
+	}
 	return [...]string{"Queued", "Pending", "Finished", "Failed"}[s]
 }
 
@@ -28,13 +31,13 @@ type ScanReports struct {
 type ScanJob struct {
 	ID      string        `json:"id"`
 	Status  ScanJobStatus `json:"status"`
+	Error   string        `json:"error"`
 	Reports *ScanReports  `json:"reports"`
 	// TODO Add Artifact field
-	// TODO Add Error field
 }
 
 // Queue manages execution of ScanJobs.
-// TODO(refactor) Split Queue into ScanEnqueuer and ScanWorker
+// TODO(refactor) Split Queue and its implementation into ScanEnqueuer and ScanWorker
 type Queue interface {
 	// Start starts this queue.
 	Start()

--- a/pkg/microscanner/wrapper.go
+++ b/pkg/microscanner/wrapper.go
@@ -82,7 +82,7 @@ func (w *wrapper) Run(imageRef, dockerConfig string) (*microscanner.ScanReport, 
 			fieldExitCode: cmd.ProcessState.ExitCode(),
 			fieldStdErr:   stderrBuffer.String(),
 		}).Error("Wrapper script failed")
-		return nil, fmt.Errorf("running %s: %v", wrapperScript, err)
+		return nil, fmt.Errorf("running %s: %v: %v", wrapperScript, err, stderrBuffer.String())
 	}
 
 	runLog.WithFields(log.Fields{

--- a/pkg/mocks/store.go
+++ b/pkg/mocks/store.go
@@ -23,8 +23,8 @@ func (m *DataStoreMock) GetScanJob(scanJobID string) (*job.ScanJob, error) {
 	return args.Get(0).(*job.ScanJob), args.Error(1)
 }
 
-func (m *DataStoreMock) UpdateStatus(scanJobID string, currentStatus, newStatus job.ScanJobStatus) error {
-	args := m.Called(scanJobID, currentStatus, newStatus)
+func (m *DataStoreMock) UpdateStatus(scanJobID string, newStatus job.ScanJobStatus, error ...string) error {
+	args := m.Called(scanJobID, newStatus, error)
 	return args.Error(0)
 }
 

--- a/pkg/store/redis/store_integration_test.go
+++ b/pkg/store/redis/store_integration_test.go
@@ -66,10 +66,7 @@ func TestRedisStore_ScanCRUD(t *testing.T) {
 			Status: job.Queued,
 		}, j)
 
-		err = dataStore.UpdateStatus(scanJobID, job.Pending, job.Finished)
-		assert.EqualError(t, err, "expected status Pending but was Queued")
-
-		err = dataStore.UpdateStatus(scanJobID, job.Queued, job.Pending)
+		err = dataStore.UpdateStatus(scanJobID, job.Pending)
 		require.NoError(t, err)
 
 		j, err = dataStore.GetScanJob(scanJobID)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -11,8 +11,7 @@ type DataStore interface {
 	// GetScanJob gets a ScanJob for the specified identifier.
 	GetScanJob(scanJobID string) (*job.ScanJob, error)
 	// UpdateStatus updates the status of the specified ScanJob.
-	// Returns an error when the actual state of the ScanJob is different then the specified currentStatus.
-	UpdateStatus(scanJobID string, currentStatus, newStatus job.ScanJobStatus) error
+	UpdateStatus(scanJobID string, newStatus job.ScanJobStatus, error ...string) error
 	// UpdateScanReports updates the ScanReports of the specified ScanJob.
 	UpdateReports(scanJobID string, reports job.ScanReports) error
 }


### PR DESCRIPTION
Resolves #18 It was partially done for GetMetadata and AcceptScanRequest HTTP handlers. In this PR I did it for GetScanReport handler. Some changes where required to bubble up the error message from the MicroScanner stderr to the HTTP layer.