### PR TITLE
feat: Support both Basic and Bearer authorization

### DIFF
--- a/pkg/docker/authorizer_test.go
+++ b/pkg/docker/authorizer_test.go
@@ -11,30 +11,77 @@ import (
 )
 
 func TestAuthorizer_Authorize(t *testing.T) {
-	authorizer := NewAuthorizer()
-	configFileName, err := authorizer.Authorize(harbor.ScanRequest{
-		Registry: harbor.Registry{
-			URL:           "core.harbor.domain",
-			Authorization: "JWTTOKENGOESHERE",
-		},
-	})
-	require.NoError(t, err)
-	configFile, err := os.Open(configFileName)
-	require.NoError(t, err)
-	bytes, err := ioutil.ReadAll(configFile)
+	testCases := []struct {
+		Name string
 
-	configJSON := `{
+		Authorization      string
+		ExpectedConfigJSON string
+		ExpectedError      string
+	}{
+		{
+			Name:          "Should authorize with Basic authorization",
+			Authorization: "Basic aGFyYm9yOnMzY3JldA==",
+			ExpectedConfigJSON: `{
  "auths": {
    "core.harbor.domain": {
-     "registrytoken":"JWTTOKENGOESHERE"
+     "auth": "aGFyYm9yOnMzY3JldA=="
    }
  },
  "HttpHeaders": {
-   "User-Agent":"Harbor Scanner MicroScanner"
+   "User-Agent": "Harbor Scanner MicroScanner"
  }
-}`
+}`,
+		},
+		{
+			Name:          "Should authorize with Bearer authorization",
+			Authorization: "Bearer JWTTOKENGOESHERE",
+			ExpectedConfigJSON: `{
+ "auths": {
+   "core.harbor.domain": {
+     "registrytoken": "JWTTOKENGOESHERE"
+   }
+ },
+ "HttpHeaders": {
+   "User-Agent": "Harbor Scanner MicroScanner"
+ }
+}`,
+		},
+		{
+			Name:          "Should return error when authorization has invalid format",
+			Authorization: "THIS_IS_INVALID",
+			ExpectedError: "parsing authorization: expected format <type> <credentials>: got: THIS_IS_INVALID",
+		},
+		{
+			Name:          "Should return error with unknown authorization type",
+			Authorization: "Unknown s3cret",
+			ExpectedError: "unrecognized authorization type: Unknown",
+		},
+	}
 
-	assert.JSONEq(t, configJSON, string(bytes))
-	err = os.RemoveAll(filepath.Dir(configFileName))
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			configFileName, err := NewAuthorizer().Authorize(harbor.ScanRequest{
+				Registry: harbor.Registry{
+					URL:           "core.harbor.domain",
+					Authorization: tc.Authorization,
+				},
+			})
+
+			if tc.ExpectedError != "" {
+				assert.EqualError(t, err, tc.ExpectedError)
+			}
+
+			if err == nil {
+				configFile, err := os.Open(configFileName)
+				require.NoError(t, err)
+				bytes, err := ioutil.ReadAll(configFile)
+
+				assert.JSONEq(t, tc.ExpectedConfigJSON, string(bytes))
+
+				err = os.RemoveAll(filepath.Dir(configFileName))
+				require.NoError(t, err)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
So far we could only authorize scanner with Bearer token. If we decide to go for Harbor robot account we need to support also Basic authorization.

What's more Basic authorization is easier for testing the scanner adapter without deploying Harbor, e.g. with private repos hosted on DockerHub.